### PR TITLE
docs(README): refresh status claims + link hygiene (H548)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # BUR — Burnouf *Dictionnaire classique sanscrit-français*
 
-_Created: 09-04-2020 · Last updated: 05-07-2026_
+_Created: 09-04-2020 · Last updated: 11-07-2026_
 
 Development and correction repository for **Émile Burnouf's *Dictionnaire classique sanscrit-français* (1866)**, a Sanskrit→French dictionary, part of the [Cologne Digital Sanskrit Lexicon](https://www.sanskrit-lexicon.uni-koeln.de/) (CDSL). The canonical source text lives in [`csl-orig/v02/bur/bur.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/bur/bur.txt) (19,776 entries); this repository holds the development, correction, and enrichment work (Greek-text insertion, verb identification, per-issue corrections).
 
 ## Documentation
 
-- [CLAUDE.md](CLAUDE.md) — repository guide and data-format reference.
-- [DATA_DICTIONARY.md](DATA_DICTIONARY.md) — markup tag reference.
-- [CONTRIBUTING.md](CONTRIBUTING.md) · [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- [CLAUDE.md](https://github.com/sanskrit-lexicon/BUR/blob/master/CLAUDE.md) — repository guide and data-format reference.
+- [DATA_DICTIONARY.md](https://github.com/sanskrit-lexicon/BUR/blob/master/DATA_DICTIONARY.md) — markup tag reference.
+- [CONTRIBUTING.md](https://github.com/sanskrit-lexicon/BUR/blob/master/CONTRIBUTING.md) · [CODE_OF_CONDUCT.md](https://github.com/sanskrit-lexicon/BUR/blob/master/CODE_OF_CONDUCT.md)
 
 ## Contents
 
 | Path | Purpose |
 |---|---|
-| `greek/` | Greek-text insertion pipeline (`prep1.py`, `digentry.py`, `proof.py`, `updateByLine.py`, proofing data) |
-| `verbs01/` | Verb-identification: maps Burnouf verb entries to roots, with Devanāgarī renderings |
-| `burissues/` | Per-issue working files (issue3, issue4, issue5) |
-| `CITATION.cff` | Machine-readable citation metadata |
-| `DATA_DICTIONARY.md` | Markup tag reference |
+| [`greek/`](https://github.com/sanskrit-lexicon/BUR/tree/master/greek) | Greek-text insertion pipeline (`prep1.py`, `digentry.py`, `proof.py`, `updateByLine.py`, proofing data) |
+| [`verbs01/`](https://github.com/sanskrit-lexicon/BUR/tree/master/verbs01) | Verb-identification: maps Burnouf verb entries to roots, with Devanāgarī renderings |
+| [`burissues/`](https://github.com/sanskrit-lexicon/BUR/tree/master/burissues) | Per-issue working files (issue3, issue4, issue5) |
+| [`CITATION.cff`](https://github.com/sanskrit-lexicon/BUR/blob/master/CITATION.cff) | Machine-readable citation metadata |
+| [`DATA_DICTIONARY.md`](https://github.com/sanskrit-lexicon/BUR/blob/master/DATA_DICTIONARY.md) | Markup tag reference |
 
 ## Usage example
 
@@ -40,7 +40,7 @@ To correct the French gloss (e.g. `sourd` → `sourde`, an agreement fix), write
 python updateByLine.py bur.txt change_60.txt bur_corrected.txt
 ```
 
-(Illustrative — no actual defect at this line; the workflow above is exact, only the fictitious agreement fix is invented to demonstrate the change-file mechanics.)
+(Illustrative — no actual defect at this line; the workflow above is exact, only the fictitious agreement fix is invented to demonstrate the change-file mechanics.) For the full paired-line change-file format, `updateByLine.py` invocation, and every gotcha (BOM, `<LEND>`, CRLF, line-count mismatch), see the canonical [correction-workflow doc](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md).
 
 ## Timeline
 
@@ -123,7 +123,7 @@ pie showData
 | Contributor | Commits |
 |---|---|
 | funderburkjim | 19 |
-| Mārcis Gasūns | 8 |
+| Mārcis Gasūns | 13 |
 | AnnaRybakovaT | 3 |
 
 ## Source
@@ -135,7 +135,7 @@ pie showData
 - **Language pair**: Sanskrit → French
 - **Entries (digital edition)**: 19,776
 - **License (digital edition)**: CC BY-SA 4.0
-- See [CITATION.cff](CITATION.cff) for machine-readable citation.
+- See [CITATION.cff](https://github.com/sanskrit-lexicon/BUR/blob/master/CITATION.cff) for machine-readable citation.
 
 ## Encoding
 


### PR DESCRIPTION
Part of handoff H548 (README audit+refactor across Cologne dictionary repos).

## Changes
- **Verified every status claim against live GitHub data.** Issue counts (1 open / 5 closed) and per-milestone splits (Digitization Quality 3, Structured Data 1, Major Enhancements 1 open + 1 closed) all confirmed accurate via `gh api` — no fabricated numbers.
- **Fixed stale contributor count**: Mārcis Gasūns 8 → 13 commits (per `git shortlog`); other counts already correct.
- **Link hygiene**: relative links (CLAUDE.md, DATA_DICTIONARY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, CITATION.cff) and bare-backtick repo paths (`greek/`, `verbs01/`, `burissues/`) converted to full github.com blob/tree URLs per org convention.
- **Linked the canonical [correction-workflow doc](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md)** from the Usage example rather than relying only on inline mechanics.
- Bumped `Last updated` to 11-07-2026; creation date (09-04-2020) preserved from git history.

No raw HTML introduced; byline and dated header intact.

Ref: [H548](https://github.com/gasyoun/Uprava/blob/main/handoffs/H548-Opus_Uprava_readme-refresh-dict-repos_10.07.26.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)